### PR TITLE
Reset jar timestamps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
-  version = '0.8.0'
+  version = '0.8.1'
   group = 'com.joom.grip'
 
   ext.kotlinVersion = '1.5.31'

--- a/library/src/main/java/com/joom/grip/io/JarFileSink.kt
+++ b/library/src/main/java/com/joom/grip/io/JarFileSink.kt
@@ -18,14 +18,16 @@ package com.joom.grip.io
 
 import com.joom.grip.commons.closeQuietly
 import java.io.File
+import java.nio.file.attribute.FileTime
 import java.util.jar.JarEntry
 import java.util.jar.JarOutputStream
 
 class JarFileSink(private val jarFile: File) : FileSink {
+  private val ZERO_FILE_TIME = FileTime.fromMillis(0L)
   private val stream = createJarOutputStream(jarFile)
 
   override fun createFile(path: String, data: ByteArray) {
-    val entry = JarEntry(path)
+    val entry = createJarEntryWithZeroTime(path)
     stream.putNextEntry(entry)
     stream.write(data)
     stream.closeEntry()
@@ -33,7 +35,7 @@ class JarFileSink(private val jarFile: File) : FileSink {
 
   override fun createDirectory(path: String) {
     val directoryPath = if (path.endsWith("/")) path else "$path/"
-    val entry = JarEntry(directoryPath)
+    val entry = createJarEntryWithZeroTime(directoryPath)
     stream.putNextEntry(entry)
     stream.closeEntry()
   }
@@ -53,5 +55,16 @@ class JarFileSink(private val jarFile: File) : FileSink {
   private fun createJarOutputStream(jarFile: File): JarOutputStream {
     jarFile.parentFile?.mkdirs()
     return JarOutputStream(jarFile.outputStream().buffered())
+  }
+
+  // timestamps for files in jar in most cases are useless.
+  // Set the modification/creation time to 0 to ensure that jars with same content
+  // always have the same checksum. It's useful for reproducible builds
+  private fun createJarEntryWithZeroTime(path: String): JarEntry {
+    return JarEntry(path).apply {
+      creationTime = ZERO_FILE_TIME
+      lastAccessTime = ZERO_FILE_TIME
+      lastModifiedTime = ZERO_FILE_TIME
+    }
   }
 }


### PR DESCRIPTION
timestamps for files in jar in most cases are useless. 
Set the modification/creation time to 0 to ensure that jars with same content always have the same checksum. It's useful for reproducible builds