### PR TITLE
Многопоточное использование Grip

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ allprojects {
 
   ext.kotlinVersion = '1.5.31'
   ext.asmVersion = '9.2'
+  ext.jsr305 = '3.0.2'
   ext.pabloVersion = '1.3.1'
 
   ext.junitVersion = '4.13.2'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -24,6 +24,7 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
 
   implementation "org.ow2.asm:asm:$asmVersion"
+  implementation "com.google.code.findbugs:jsr305:$jsr305"
 
   testImplementation "junit:junit:$junitVersion"
   testImplementation "org.mockito:mockito-core:$mockitoVersion"

--- a/library/src/main/java/com/joom/grip/ClassRegistry.kt
+++ b/library/src/main/java/com/joom/grip/ClassRegistry.kt
@@ -28,7 +28,9 @@ import org.objectweb.asm.Opcodes
 import java.lang.annotation.Retention
 import java.lang.annotation.RetentionPolicy
 import java.util.concurrent.ConcurrentHashMap
+import javax.annotation.concurrent.ThreadSafe
 
+@ThreadSafe
 interface ClassRegistry {
   fun getClassMirror(type: Type.Object): ClassMirror
   fun getAnnotationMirror(type: Type.Object): AnnotationMirror

--- a/library/src/main/java/com/joom/grip/FileRegistry.kt
+++ b/library/src/main/java/com/joom/grip/FileRegistry.kt
@@ -23,7 +23,9 @@ import com.joom.grip.mirrors.Type
 import com.joom.grip.mirrors.getObjectTypeByInternalName
 import java.io.Closeable
 import java.io.File
+import javax.annotation.concurrent.ThreadSafe
 
+@ThreadSafe
 interface FileRegistry {
   operator fun contains(file: File): Boolean
   operator fun contains(type: Type.Object): Boolean

--- a/library/src/main/java/com/joom/grip/Grip.kt
+++ b/library/src/main/java/com/joom/grip/Grip.kt
@@ -17,7 +17,9 @@
 package com.joom.grip
 
 import java.io.Closeable
+import javax.annotation.concurrent.ThreadSafe
 
+@ThreadSafe
 interface Grip : Closeable {
   val fileRegistry: FileRegistry
   val classRegistry: ClassRegistry

--- a/library/src/main/java/com/joom/grip/GripFactory.kt
+++ b/library/src/main/java/com/joom/grip/GripFactory.kt
@@ -20,7 +20,9 @@ import com.joom.grip.io.IoFactory
 import com.joom.grip.mirrors.ReflectorImpl
 import org.objectweb.asm.Opcodes
 import java.io.File
+import javax.annotation.concurrent.ThreadSafe
 
+@ThreadSafe
 interface GripFactory {
   fun create(file: File, vararg files: File): Grip
   fun create(files: Iterable<File>): Grip


### PR DESCRIPTION
Хочу использовать один и тот же инстанс Grip из разных потоков. По коду кажется, что сейчас только `ClassRegistryImpl` не очень к этому готов. Во всех остальных классах вроде должно быть все ок. В этом PR сделал:
- В `ClassRegistryImpl` заменил использования `HashMap` на `ConcurrentHashMap`
- Пометил основные интерфейсы как `@ThreadSafe` 