### PR TITLE
Ability to combine multiple Grip instances into one

### DIFF
--- a/library/src/main/java/com/joom/grip/CombinedGripFactory.kt
+++ b/library/src/main/java/com/joom/grip/CombinedGripFactory.kt
@@ -17,6 +17,7 @@
 package com.joom.grip
 
 import com.joom.grip.commons.immutable
+import com.joom.grip.commons.singleOrNullIfNotFound
 import com.joom.grip.mirrors.AnnotationMirror
 import com.joom.grip.mirrors.ClassMirror
 import com.joom.grip.mirrors.Type
@@ -109,8 +110,8 @@ private class CombinedFileRegistryImpl(private val registries: Iterable<FileRegi
       return it
     }
 
-    return registries.firstOrNull { it.contains(type) }?.also {
-      typeToRegistry[type] = it
+    return registries.singleOrNullIfNotFound({ "Multiple registries contain same type ${type.internalName}" }) {
+      it.contains(type)
     }
   }
 
@@ -119,8 +120,8 @@ private class CombinedFileRegistryImpl(private val registries: Iterable<FileRegi
       return it
     }
 
-    return registries.firstOrNull { it.contains(path) }?.also {
-      pathToRegistry[path] = it
+    return registries.singleOrNullIfNotFound({ "Multiple registries contain same path $path" }) {
+      it.contains(path)
     }
   }
 }

--- a/library/src/main/java/com/joom/grip/CombinedGripFactory.kt
+++ b/library/src/main/java/com/joom/grip/CombinedGripFactory.kt
@@ -18,6 +18,7 @@ package com.joom.grip
 
 import com.joom.grip.commons.immutable
 import com.joom.grip.commons.singleOrNullIfNotFound
+import com.joom.grip.commons.toAbsoluteNormalized
 import com.joom.grip.mirrors.AnnotationMirror
 import com.joom.grip.mirrors.ClassMirror
 import com.joom.grip.mirrors.Type
@@ -116,12 +117,13 @@ private class CombinedFileRegistryImpl(private val registries: Iterable<FileRegi
   }
 
   private fun registryByPath(path: Path): FileRegistry? {
-    pathToRegistry[path]?.let {
+    val normalizedPath = path.toAbsoluteNormalized()
+    pathToRegistry[normalizedPath]?.let {
       return it
     }
 
-    return registries.singleOrNullIfNotFound({ "Multiple registries contain same path $path" }) {
-      it.contains(path)
+    return registries.singleOrNullIfNotFound({ "Multiple registries contain same path $normalizedPath" }) {
+      it.contains(normalizedPath)
     }
   }
 }

--- a/library/src/main/java/com/joom/grip/CombinedGripFactory.kt
+++ b/library/src/main/java/com/joom/grip/CombinedGripFactory.kt
@@ -21,7 +21,9 @@ import com.joom.grip.mirrors.ClassMirror
 import com.joom.grip.mirrors.Type
 import java.nio.file.Path
 import java.util.concurrent.ConcurrentHashMap
+import javax.annotation.concurrent.ThreadSafe
 
+@ThreadSafe
 interface CombinedGripFactory {
   fun create(grip: Grip, vararg grips: Grip): Grip
   fun create(grips: Iterable<Grip>): Grip

--- a/library/src/main/java/com/joom/grip/CombinedGripFactory.kt
+++ b/library/src/main/java/com/joom/grip/CombinedGripFactory.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2022 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.grip
+
+import com.joom.grip.mirrors.AnnotationMirror
+import com.joom.grip.mirrors.ClassMirror
+import com.joom.grip.mirrors.Type
+import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
+
+interface CombinedGripFactory {
+  fun create(grip: Grip, vararg grips: Grip): Grip
+  fun create(grips: Iterable<Grip>): Grip
+
+  companion object {
+    @JvmStatic
+    val INSTANCE: CombinedGripFactory = CombinedGripFactoryImpl()
+  }
+}
+
+private class CombinedGripFactoryImpl : CombinedGripFactory {
+  override fun create(grips: Iterable<Grip>): Grip {
+    val classRegistry = CombinedClassRegistryImpl(grips)
+    val fileRegistry = CombinedFileRegistryImpl(grips.map { it.fileRegistry })
+
+    return GripImpl(fileRegistry, classRegistry, grips)
+  }
+
+  override fun create(grip: Grip, vararg grips: Grip): Grip {
+    return create(listOf(grip) + grips.asList())
+  }
+}
+
+private class CombinedClassRegistryImpl(private val grips: Iterable<Grip>) : ClassRegistry {
+  private val annotationTypeToGrip = ConcurrentHashMap<Type.Object, Grip>()
+  private val typeToGrip = ConcurrentHashMap<Type.Object, Grip>()
+  override fun getAnnotationMirror(type: Type.Object): AnnotationMirror {
+    val grip = annotationTypeToGrip.getOrPut(type) {
+      grips.first { it.fileRegistry.contains(type) }
+    }
+
+    return grip.classRegistry.getAnnotationMirror(type)
+  }
+
+  override fun getClassMirror(type: Type.Object): ClassMirror {
+    val grip = typeToGrip.getOrPut(type) {
+      grips.first { it.fileRegistry.contains(type) }
+    }
+
+    return grip.classRegistry.getClassMirror(type)
+  }
+}
+
+private class CombinedFileRegistryImpl(private val registries: Iterable<FileRegistry>) : FileRegistry {
+  private val typeToRegistry = ConcurrentHashMap<Type.Object, FileRegistry>()
+  private val pathToRegistry = ConcurrentHashMap<Path, FileRegistry>()
+
+  private val classpath by lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
+    registries.flatMap { it.classpath() }
+  }
+
+  override fun classpath(): Collection<Path> {
+    return classpath
+  }
+
+  override fun readClass(type: Type.Object): ByteArray {
+    return registryByType(type)?.readClass(type) ?: run {
+      throw IllegalArgumentException("Unable to find registry for ${type.internalName}")
+    }
+  }
+
+  override fun contains(path: Path): Boolean {
+    return registryByPath(path) != null
+  }
+
+  override fun contains(type: Type.Object): Boolean {
+    return registryByType(type) != null
+  }
+
+  override fun findPathForType(type: Type.Object): Path? {
+    return registryByType(type)?.findPathForType(type)
+  }
+
+  override fun findTypesForPath(path: Path): Collection<Type.Object> {
+    return registryByPath(path)?.findTypesForPath(path) ?: run {
+      throw IllegalArgumentException("File $path is not added to the registry")
+    }
+  }
+
+  private fun registryByType(type: Type.Object): FileRegistry? {
+    typeToRegistry[type]?.let {
+      return it
+    }
+
+    return registries.firstOrNull { it.contains(type) }?.also {
+      typeToRegistry[type] = it
+    }
+  }
+
+  private fun registryByPath(path: Path): FileRegistry? {
+    pathToRegistry[path]?.let {
+      return it
+    }
+
+    return registries.firstOrNull { it.contains(path) }?.also {
+      pathToRegistry[path] = it
+    }
+  }
+}

--- a/library/src/main/java/com/joom/grip/CombinedGripFactory.kt
+++ b/library/src/main/java/com/joom/grip/CombinedGripFactory.kt
@@ -16,6 +16,7 @@
 
 package com.joom.grip
 
+import com.joom.grip.commons.immutable
 import com.joom.grip.mirrors.AnnotationMirror
 import com.joom.grip.mirrors.ClassMirror
 import com.joom.grip.mirrors.Type
@@ -72,7 +73,7 @@ private class CombinedFileRegistryImpl(private val registries: Iterable<FileRegi
   private val pathToRegistry = ConcurrentHashMap<Path, FileRegistry>()
 
   private val classpath by lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
-    registries.flatMap { it.classpath() }
+    registries.flatMap { it.classpath() }.immutable()
   }
 
   override fun classpath(): Collection<Path> {

--- a/library/src/main/java/com/joom/grip/Grip.kt
+++ b/library/src/main/java/com/joom/grip/Grip.kt
@@ -30,7 +30,7 @@ interface Grip : Closeable {
 internal class GripImpl(
   override val fileRegistry: FileRegistry,
   override val classRegistry: ClassRegistry,
-  private val closeable: Closeable
+  private vararg val closeables: Closeable
 ) : Grip {
 
   private var closed = false
@@ -42,7 +42,9 @@ internal class GripImpl(
 
   override fun close() {
     try {
-      closeable.close()
+      closeables.forEach {
+        it.close()
+      }
     } finally {
       closed = true
     }

--- a/library/src/main/java/com/joom/grip/Grip.kt
+++ b/library/src/main/java/com/joom/grip/Grip.kt
@@ -30,7 +30,7 @@ interface Grip : Closeable {
 internal class GripImpl(
   override val fileRegistry: FileRegistry,
   override val classRegistry: ClassRegistry,
-  private vararg val closeables: Closeable
+  private val closeables: Iterable<Closeable> = emptyList()
 ) : Grip {
 
   private var closed = false

--- a/library/src/main/java/com/joom/grip/GripFactory.kt
+++ b/library/src/main/java/com/joom/grip/GripFactory.kt
@@ -55,6 +55,6 @@ internal class GripFactoryImpl(
     val fileRegistry = FileRegistryImpl(paths, IoFactory)
     val reflector = ReflectorImpl(asmApi)
     val classRegistry = ClassRegistryImpl(fileRegistry, reflector)
-    return GripImpl(fileRegistry, classRegistry, fileRegistry)
+    return GripImpl(fileRegistry, classRegistry, fileRegistry, classRegistry)
   }
 }

--- a/library/src/main/java/com/joom/grip/GripFactory.kt
+++ b/library/src/main/java/com/joom/grip/GripFactory.kt
@@ -55,6 +55,6 @@ internal class GripFactoryImpl(
     val fileRegistry = FileRegistryImpl(paths, IoFactory)
     val reflector = ReflectorImpl(asmApi)
     val classRegistry = ClassRegistryImpl(fileRegistry, reflector)
-    return GripImpl(fileRegistry, classRegistry, fileRegistry, classRegistry)
+    return GripImpl(fileRegistry, classRegistry, listOf(fileRegistry, classRegistry))
   }
 }

--- a/library/src/main/java/com/joom/grip/commons/CollectionsExtensions.kt
+++ b/library/src/main/java/com/joom/grip/commons/CollectionsExtensions.kt
@@ -26,3 +26,17 @@ internal fun <K, V> Map<K, V>.immutable(): Map<K, V> = Collections.unmodifiableM
 internal fun <T> Set<T>.immutable(): Set<T> = Collections.unmodifiableSet(this)
 internal fun <K, V> SortedMap<K, V>.immutable(): SortedMap<K, V> = Collections.unmodifiableSortedMap(this)
 internal fun <T> SortedSet<T>.immutable(): SortedSet<T> = Collections.unmodifiableSortedSet(this)
+internal inline fun <T : Any> Iterable<T>.singleOrNullIfNotFound(message: () -> String, predicate: (T) -> Boolean): T? {
+  var found: T? = null
+  forEach {
+    if (predicate(it)) {
+      if (found != null) {
+        throw IllegalArgumentException(message())
+      } else {
+        found = it
+      }
+    }
+  }
+
+  return found
+}

--- a/library/src/test/java/com/joom/grip/ClassRegistryImplTest.kt
+++ b/library/src/test/java/com/joom/grip/ClassRegistryImplTest.kt
@@ -25,6 +25,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.nio.file.Paths
 
 class ClassRegistryImplTest {
   private lateinit var classRegistry: ClassRegistry
@@ -32,6 +33,7 @@ class ClassRegistryImplTest {
   @Before
   fun createClassRegistry() {
     val fileRegistry = TestFileRegistry(
+      Paths.get("/"),
       Annotation1::class,
       Annotation2::class
     )

--- a/library/src/test/java/com/joom/grip/CombinedGripTest.kt
+++ b/library/src/test/java/com/joom/grip/CombinedGripTest.kt
@@ -62,6 +62,26 @@ class CombinedGripTest {
     (grip select classes from Path("/some-path") where isPublic()).execute()
   }
 
+  @Test(expected = IllegalArgumentException::class)
+  fun throwsMultipleGripInstancesContainSamePath() {
+    val grip = CombinedGripFactory.INSTANCE.create(
+      TestGripFactory.create(FIRST_PATH, Class1::class),
+      TestGripFactory.create(FIRST_PATH, Class1::class),
+    )
+
+    grip.fileRegistry.contains(FIRST_PATH)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun throwsMultipleGripInstancesContainSameType() {
+    val grip = CombinedGripFactory.INSTANCE.create(
+      TestGripFactory.create(FIRST_PATH, Class1::class),
+      TestGripFactory.create(SECOND_PATH, Class1::class),
+    )
+
+    grip.fileRegistry.contains(getObjectType<Class1>())
+  }
+
   private fun createCombinedGrip(): Grip {
     return CombinedGripFactory.INSTANCE.create(
       TestGripFactory.create(FIRST_PATH, Class1::class, Annotation1::class),

--- a/library/src/test/java/com/joom/grip/CombinedGripTest.kt
+++ b/library/src/test/java/com/joom/grip/CombinedGripTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.joom.grip
+
+import com.joom.grip.classes.Annotation1
+import com.joom.grip.classes.Annotation2
+import com.joom.grip.classes.Class1
+import com.joom.grip.classes.Class2
+import com.joom.grip.classes.Enum1
+import com.joom.grip.mirrors.getObjectType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import kotlin.io.path.Path
+
+class CombinedGripTest {
+
+  private val grip = createCombinedGrip()
+
+  @Test
+  fun testClasses() {
+    val paths = listOf(FIRST_PATH, SECOND_PATH, THIRD_PATH)
+
+    assertClassesResultContains<Class1>(
+      grip select classes from paths where (name(contains("Class1")) and isPublic())
+    )
+
+    assertClassesResultContains<Class2>(
+      grip select classes from paths where (name(contains("Class2")) and isPublic())
+    )
+
+    assertClassesResultContains<Class1>(
+      grip select classes from paths where (annotatedWith(getObjectType<Annotation1>()))
+    )
+  }
+
+  @Test
+  fun testMethods() {
+    val paths = listOf(FIRST_PATH, SECOND_PATH, THIRD_PATH)
+
+    val classes = grip select classes from paths where name(contains("Class"))
+    val methods = grip select methods from classes where (not(isStatic()) and not(isConstructor()))
+    assertEquals(1, methods.execute()[getObjectType<Class1>()]!!.size)
+    assertEquals(1, methods.execute()[getObjectType<Class2>()]!!.size)
+  }
+
+  @Test(expected = IllegalArgumentException::class)
+  fun throwsForNotAddedPath() {
+    (grip select classes from Path("/some-path") where isPublic()).execute()
+  }
+
+  private fun createCombinedGrip(): Grip {
+    return CombinedGripFactory.INSTANCE.create(
+      TestGripFactory.create(FIRST_PATH, Class1::class, Annotation1::class),
+      TestGripFactory.create(SECOND_PATH, Class2::class, Annotation2::class),
+      TestGripFactory.create(THIRD_PATH, Enum1::class),
+    )
+  }
+
+  private inline fun <reified T : Any> assertClassesResultContains(query: Query<ClassesResult>) {
+    val result = query.execute()
+    val type = getObjectType<T>()
+    assert(result.classes.any { it.type == type })
+  }
+
+  private companion object {
+    private val FIRST_PATH = Path("/first")
+    private val SECOND_PATH = Path("/second")
+    private val THIRD_PATH = Path("/third")
+  }
+}

--- a/library/src/test/java/com/joom/grip/GripTest.kt
+++ b/library/src/test/java/com/joom/grip/GripTest.kt
@@ -21,35 +21,32 @@ import com.joom.grip.classes.Annotation2
 import com.joom.grip.classes.Class1
 import com.joom.grip.classes.Class2
 import com.joom.grip.classes.Enum1
-import com.joom.grip.mirrors.ReflectorImpl
 import com.joom.grip.mirrors.getObjectType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import java.nio.file.Paths
+import kotlin.io.path.Path
 
 class GripTest {
   private lateinit var grip: Grip
 
   @Before
   fun createGrip() {
-    val fileRegistry = TestFileRegistry(
+    grip = TestGripFactory.create(
+      Path(""),
       Class1::class,
       Class2::class,
       Annotation1::class,
       Annotation2::class,
       Enum1::class
     )
-    val reflector = ReflectorImpl(GripFactory.ASM_API_DEFAULT)
-    val classRegistry = ClassRegistryImpl(fileRegistry, reflector)
-    grip = GripImpl(fileRegistry, classRegistry)
   }
 
   @Test
   fun testClasses() {
-    val path = Paths.get("")
+    val path = Path("")
     assertClassesResultContains<Class1>(
       grip select classes from path where (name(contains("Class1")) and isPublic())
     )
@@ -69,7 +66,7 @@ class GripTest {
 
   @Test
   fun testMethods() {
-    val path = Paths.get("")
+    val path = Path("")
     val classes = grip select classes from path where name(contains("Class"))
     val methods = grip select methods from classes where (not(isStatic()) and not(isConstructor()))
     assertEquals(1, methods.execute()[getObjectType<Class1>()]!!.size)
@@ -80,7 +77,7 @@ class GripTest {
   fun testClose() {
     grip.close()
 
-    val path = Paths.get("")
+    val path = Path("")
     (grip select classes from path where name(contains("Class"))).execute()
   }
 

--- a/library/src/test/java/com/joom/grip/GripTest.kt
+++ b/library/src/test/java/com/joom/grip/GripTest.kt
@@ -23,12 +23,12 @@ import com.joom.grip.classes.Class2
 import com.joom.grip.classes.Enum1
 import com.joom.grip.mirrors.ReflectorImpl
 import com.joom.grip.mirrors.getObjectType
-import java.nio.file.Paths
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.nio.file.Paths
 
 class GripTest {
   private lateinit var grip: Grip
@@ -44,7 +44,7 @@ class GripTest {
     )
     val reflector = ReflectorImpl(GripFactory.ASM_API_DEFAULT)
     val classRegistry = ClassRegistryImpl(fileRegistry, reflector)
-    grip = GripImpl(fileRegistry, classRegistry) {}
+    grip = GripImpl(fileRegistry, classRegistry)
   }
 
   @Test
@@ -74,6 +74,14 @@ class GripTest {
     val methods = grip select methods from classes where (not(isStatic()) and not(isConstructor()))
     assertEquals(1, methods.execute()[getObjectType<Class1>()]!!.size)
     assertEquals(1, methods.execute()[getObjectType<Class2>()]!!.size)
+  }
+
+  @Test(expected = IllegalStateException::class)
+  fun testClose() {
+    grip.close()
+
+    val path = Paths.get("")
+    (grip select classes from path where name(contains("Class"))).execute()
   }
 
   private inline fun <reified T : Any> assertClassesResultContains(query: Query<ClassesResult>) {

--- a/library/src/test/java/com/joom/grip/TestGripFactory.kt
+++ b/library/src/test/java/com/joom/grip/TestGripFactory.kt
@@ -1,0 +1,15 @@
+package com.joom.grip
+
+import com.joom.grip.mirrors.ReflectorImpl
+import java.nio.file.Path
+import kotlin.reflect.KClass
+
+object TestGripFactory {
+  fun create(path: Path, vararg classes: KClass<*>): Grip {
+    val fileRegistry = TestFileRegistry(path, *classes)
+    val reflector = ReflectorImpl(GripFactory.ASM_API_DEFAULT)
+    val classRegistry = ClassRegistryImpl(fileRegistry, reflector)
+
+    return GripImpl(fileRegistry, classRegistry)
+  }
+}

--- a/library/src/test/java/com/joom/grip/TestGripFactory.kt
+++ b/library/src/test/java/com/joom/grip/TestGripFactory.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 SIA Joom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.joom.grip
 
 import com.joom.grip.mirrors.ReflectorImpl


### PR DESCRIPTION
Introduced `CombinedGripFactory` that allows combining multiple `Grip` instances into one. This can be used for sharing `Grip` instances for same `Path`.